### PR TITLE
Added persistent retry condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 PROJECT_NAME := runner
 TEST_REPORT := test-report.out
 COVERAGE_REPORT := coverage.out
-PACKAGE_LIST := ./
+PACKAGE_LIST := ./...
 
 TARGETS := $(shell go tool dist list)
 

--- a/README.md
+++ b/README.md
@@ -96,17 +96,26 @@ git -> jdberry-tag -> ai-tag -> ai-organize-file
 
 Define conditions that need to be met before (`check:`) or after (`expect:`) a step runs. You can also specify skip conditions using the `skip:` array.
 
-Negate any condition by prefixing it with `!`.
-
 ```yaml
 check:
   - "ENV:THIS_PREFLIGHT_ENV_VAR_SHOULD_EXIST"
   - "!ENV:SHOULD_NOT_EXIST"
+  - "@URL:https://example.com:3000/api/v2"
 expect:
   - "CMD:this_postflight_command_check_should_be_available_in_path"
 skip:
   - "FILE:/skip/if/this/file/exists.txt"
 ```
+
+### Negation and Persistence Flags
+
+You can negate a condition by prefixing it with `!`, for example, `!ENV:SHOULD_NOT_EXIST`.
+
+To make a condition persistent, prefix it with `@`, such as `@FILE:/tmp/awaiting_for_this_file.txt`.
+Persistent conditions will be retried until they are satisfied.
+
+Persistent flags applies to all prefixes except `ENV:`. It can be combined with
+negation. i.e. "!@CMD:SHOULD_BE_NOT_AVAILABLE"
 
 ### Supported Check Prefixes
 
@@ -116,6 +125,7 @@ skip:
 - `URL:` – Confirms if a URL is reachable.
 - `CMD:` – Ensures a command is available in the `$PATH`.
 - `EXEC:` – Runs a command to check if it completes successfully (exit code 0).
+- `a string value:` - Check if the text exists on the output.
 
 ### Setting Environment Variables
 

--- a/pkg/expect/check/check.go
+++ b/pkg/expect/check/check.go
@@ -1,157 +1,203 @@
 package check
 
 import (
-	"fmt"
-	"net/http"
-	"os"
-	"os/exec"
-	"strconv"
-	"strings"
+    "fmt"
+    "net/http"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+    "time"
 
-	"github.com/jjuliano/runner/pkg/expect/process"
-	"github.com/jjuliano/runner/pkg/runnerexec"
+    "github.com/jjuliano/runner/pkg/expect/process"
+    "github.com/jjuliano/runner/pkg/runnerexec"
 )
 
 // addDefaultProtocol ensures the URL has a protocol. If missing, it adds "http://"
 func addDefaultProtocol(url string) string {
-	if !strings.Contains(url, "://") {
-		return "http://" + url
-	}
-	return url
+    if !strings.Contains(url, "://") {
+        return "http://" + url
+    }
+    return url
+}
+
+// retryCheck attempts the check indefinitely if persistent, or returns an error for non-persistent checks.
+func retryCheck(checkFunc func() error, persistent bool) error {
+    const retryDelay = 2 * time.Second
+    attempts := 0
+    for {
+        attempts++
+        err := checkFunc()
+        if err == nil {
+            return nil
+        }
+
+        // Log the failed attempt
+        fmt.Printf("Attempt %d failed: %v\n", attempts, err)
+
+        if !persistent {
+            return err // If not persistent, return the error immediately
+        }
+
+        // Log the retry action
+        fmt.Printf("Retrying in %s (attempt %d)\n", retryDelay, attempts)
+        time.Sleep(retryDelay) // Wait before retrying
+    }
 }
 
 // CheckExpectations verifies if the output or exit code matches the expectations.
 func CheckExpectations(output string, exitCode int, expectations []string, client *http.Client) error {
-	for _, exp := range expectations {
-		isNegation := strings.HasPrefix(exp, "!")
-		expectation := strings.TrimPrefix(exp, "!")
-		expectation = process.ReplaceVars(expectation)
+    for _, exp := range expectations {
+        isNegation := strings.HasPrefix(exp, "!")
+        persistent := strings.HasPrefix(exp, "@") || strings.HasPrefix(exp, "!@")
+        expectation := strings.TrimPrefix(strings.TrimPrefix(exp, "@"), "!@")
+        expectation = strings.TrimPrefix(expectation, "!")
+        expectation = process.ReplaceVars(expectation)
 
-		// Check if the expectation is a command to execute
-		if strings.HasPrefix(expectation, "CMD:") {
-			cmd := strings.TrimPrefix(expectation, "CMD:")
-			path, err := runnerexec.Which(cmd)
-			if isNegation {
-				if err == nil {
-					return fmt.Errorf("unexpected executable path '%s' exists", path)
-				}
-			} else {
-				if err != nil {
-					return fmt.Errorf("expected executable path '%s' does not exist", cmd)
-				}
-			}
-			continue
-		}
+        // Define the check function as a closure
+        checkFunc := func() error {
+            // Check if the expectation is a command to execute
+            if strings.HasPrefix(expectation, "CMD:") {
+                cmd := strings.TrimPrefix(expectation, "CMD:")
+                path, err := runnerexec.Which(cmd)
+                if isNegation {
+                    if err == nil {
+                        return fmt.Errorf("unexpected executable path '%s' exists", path)
+                    }
+                } else {
+                    if err != nil {
+                        return fmt.Errorf("expected executable path '%s' does not exist", cmd)
+                    }
+                }
+                return nil
+            }
 
-		// Check if the expectation is a command to execute and verify its exit status
-		if strings.HasPrefix(expectation, "EXEC:") {
-			cmdStr := strings.TrimPrefix(expectation, "EXEC:")
-			cmdParts := strings.Fields(cmdStr)
-			if len(cmdParts) == 0 {
-				return fmt.Errorf("invalid EXEC command")
-			}
+            // Check if the expectation is a command to execute and verify its exit status
+            if strings.HasPrefix(expectation, "EXEC:") {
+                cmdStr := strings.TrimPrefix(expectation, "EXEC:")
+                cmdParts := strings.Fields(cmdStr)
+                if len(cmdParts) == 0 {
+                    return fmt.Errorf("invalid EXEC command")
+                }
 
-			cmd := exec.Command(cmdParts[0], cmdParts[1:]...)
-			output, err := cmd.CombinedOutput()
-			if isNegation {
-				if err == nil {
-					return fmt.Errorf("unexpected command '%s' ran successfully: %s", cmdStr, output)
-				}
-			} else {
-				if err != nil {
-					return fmt.Errorf("command '%s' failed: %v, output: %s", cmdStr, err, output)
-				}
-			}
-			continue
-		}
+                cmd := exec.Command(cmdParts[0], cmdParts[1:]...)
+                output, err := cmd.CombinedOutput()
+                if isNegation {
+                    if err == nil {
+                        return fmt.Errorf("unexpected command '%s' ran successfully: %s", cmdStr, output)
+                    }
+                } else {
+                    if err != nil {
+                        return fmt.Errorf("command '%s' failed: %v, output: %s", cmdStr, err, output)
+                    }
+                }
+                return nil
+            }
 
-		// Check if the expectation is an exit code (number)
-		if expectNum, err := strconv.Atoi(expectation); err == nil {
-			if isNegation {
-				if exitCode == expectNum {
-					return fmt.Errorf("unexpected exit status '%d'", exitCode)
-				}
-			} else {
-				if exitCode != expectNum {
-					return fmt.Errorf("expected exit status '%d' but got '%d'", expectNum, exitCode)
-				}
-			}
-			continue
-		}
+            // Check if the expectation is an exit code (number)
+            if expectNum, err := strconv.Atoi(expectation); err == nil {
+                if isNegation {
+                    if exitCode == expectNum {
+                        return fmt.Errorf("unexpected exit status '%d'", exitCode)
+                    }
+                } else {
+                    if exitCode != expectNum {
+                        return fmt.Errorf("expected exit status '%d' but got '%d'", expectNum, exitCode)
+                    }
+                }
+                return nil
+            }
 
-		// Check if the expectation is an environment variable
-		if strings.HasPrefix(expectation, "ENV:") {
-			envVar := strings.TrimPrefix(expectation, "ENV:")
-			_, exists := os.LookupEnv(envVar)
-			if isNegation {
-				if exists {
-					return fmt.Errorf("unexpected environment variable '%s' exists", envVar)
-				}
-			} else {
-				if !exists {
-					return fmt.Errorf("expected environment variable '%s' does not exist", envVar)
-				}
-			}
-			continue
-		}
+            // Check if the expectation is an environment variable (without persistence)
+            if strings.HasPrefix(expectation, "ENV:") {
+                envVar := strings.TrimPrefix(expectation, "ENV:")
+                _, exists := os.LookupEnv(envVar)
+                if isNegation {
+                    if exists {
+                        return fmt.Errorf("unexpected environment variable '%s' exists", envVar)
+                    }
+                } else {
+                    if !exists {
+                        return fmt.Errorf("expected environment variable '%s' does not exist", envVar)
+                    }
+                }
+                return nil
+            }
 
-		// Check if the expectation is a file
-		if strings.HasPrefix(expectation, "FILE:") {
-			filePath := strings.TrimPrefix(expectation, "FILE:")
-			if isNegation {
-				if _, err := os.Stat(filePath); err == nil {
-					return fmt.Errorf("unexpected file '%s' exists", filePath)
-				}
-			} else {
-				if _, err := os.Stat(filePath); os.IsNotExist(err) {
-					return fmt.Errorf("expected file '%s' does not exist", filePath)
-				}
-			}
-			continue
-		}
+            // Check if the expectation is a file
+            if strings.HasPrefix(expectation, "FILE:") {
+                filePath := strings.TrimPrefix(expectation, "FILE:")
+                if isNegation {
+                    if _, err := os.Stat(filePath); err == nil {
+                        return fmt.Errorf("unexpected file '%s' exists", filePath)
+                    }
+                } else {
+                    if _, err := os.Stat(filePath); os.IsNotExist(err) {
+                        return fmt.Errorf("expected file '%s' does not exist", filePath)
+                    }
+                }
+                return nil
+            }
 
-		// Check if the expectation is a directory
-		if strings.HasPrefix(expectation, "DIR:") {
-			dirPath := strings.TrimPrefix(expectation, "DIR:")
-			if isNegation {
-				if info, err := os.Stat(dirPath); err == nil && info.IsDir() {
-					return fmt.Errorf("unexpected directory '%s' exists", dirPath)
-				}
-			} else {
-				if info, err := os.Stat(dirPath); os.IsNotExist(err) || !info.IsDir() {
-					return fmt.Errorf("expected directory '%s' does not exist", dirPath)
-				}
-			}
-			continue
-		}
+            // Check if the expectation is a directory
+            if strings.HasPrefix(expectation, "DIR:") {
+                dirPath := strings.TrimPrefix(expectation, "DIR:")
+                if isNegation {
+                    if info, err := os.Stat(dirPath); err == nil && info.IsDir() {
+                        return fmt.Errorf("unexpected directory '%s' exists", dirPath)
+                    }
+                } else {
+                    if info, err := os.Stat(dirPath); os.IsNotExist(err) || !info.IsDir() {
+                        return fmt.Errorf("expected directory '%s' does not exist", dirPath)
+                    }
+                }
+                return nil
+            }
 
-		// Check if the expectation is a URL
-		if strings.HasPrefix(expectation, "URL:") {
-			url := strings.TrimPrefix(expectation, "URL:")
-			url = addDefaultProtocol(url) // Ensure the URL has a protocol
-			resp, err := client.Head(url)
-			if isNegation {
-				if err == nil && resp.StatusCode == http.StatusOK {
-					return fmt.Errorf("unexpected URL '%s' is accessible", url)
-				}
-			} else {
-				if err != nil || resp.StatusCode != http.StatusOK {
-					return fmt.Errorf("expected URL '%s' is not accessible", url)
-				}
-			}
-			continue
-		}
+            // Check if the expectation is a URL
+            if strings.HasPrefix(expectation, "URL:") {
+                url := strings.TrimPrefix(expectation, "URL:")
+                url = addDefaultProtocol(url) // Ensure the URL has a protocol
+                resp, err := client.Head(url)
+                if isNegation {
+                    if err == nil && resp.StatusCode == http.StatusOK {
+                        return fmt.Errorf("unexpected URL '%s' is accessible", url)
+                    }
+                } else {
+                    if err != nil || resp.StatusCode != http.StatusOK {
+                        return fmt.Errorf("expected URL '%s' is not accessible", url)
+                    }
+                }
+                return nil
+            }
 
-		// Default string expectation check
-		if isNegation {
-			if strings.Contains(strings.ToLower(output), strings.ToLower(expectation)) {
-				return fmt.Errorf("unexpected output: found '%s'", expectation)
-			}
-		} else {
-			if !strings.Contains(strings.ToLower(output), strings.ToLower(expectation)) {
-				return fmt.Errorf("expected '%s' not found in output", expectation)
-			}
-		}
-	}
-	return nil
+            // Default string expectation check
+            if isNegation {
+                if strings.Contains(strings.ToLower(output), strings.ToLower(expectation)) {
+                    return fmt.Errorf("unexpected output: found '%s'", expectation)
+                }
+            } else {
+                if !strings.Contains(strings.ToLower(output), strings.ToLower(expectation)) {
+                    return fmt.Errorf("expected '%s' not found in output", expectation)
+                }
+            }
+
+            return nil
+        }
+
+        // Skip persistent retry for environment variables
+        if strings.HasPrefix(expectation, "ENV:") {
+            err := checkFunc()
+            if err != nil {
+                return err
+            }
+        } else {
+            // If persistent, retry the check function
+            err := retryCheck(checkFunc, persistent)
+            if err != nil {
+                return err
+            }
+        }
+    }
+    return nil
 }

--- a/pkg/expect/expect.go
+++ b/pkg/expect/expect.go
@@ -1,12 +1,11 @@
-// expect.go
 package expect
 
 import (
-	"github.com/jjuliano/runner/pkg/expect/check"
-	"github.com/jjuliano/runner/pkg/expect/process"
+    "github.com/jjuliano/runner/pkg/expect/check"
+    "github.com/jjuliano/runner/pkg/expect/process"
 )
 
 var (
-	ProcessExpectations = process.ProcessExpectations
-	CheckExpectations   = check.CheckExpectations
+    ProcessExpectations = process.ProcessExpectations
+    CheckExpectations   = check.CheckExpectations
 )

--- a/pkg/resolver/commands.go
+++ b/pkg/resolver/commands.go
@@ -94,7 +94,7 @@ func SourceEnvFile(envFilePath string) error {
         if err != nil {
             LogError(fmt.Sprintf("Failed to close environment file: %s - %v", envFilePath, err), err)
         } else {
-            LogInfo(fmt.Sprintf("Successfully closed environment file: %s", envFilePath))
+            LogDebug(fmt.Sprintf("Successfully closed environment file: %s", envFilePath))
         }
     }(file)
 
@@ -113,14 +113,14 @@ func SourceEnvFile(envFilePath string) error {
         if err := os.Setenv(key, value); err != nil {
             return LogError(fmt.Sprintf("Failed to set environment variable %s: %v - %s", key, err, envFilePath), err)
         }
-        LogInfo(fmt.Sprintf("Set environment variable %s=%s", key, value))
+        LogDebug(fmt.Sprintf("Set environment variable %s=%s", key, value))
     }
 
     if err := scanner.Err(); err != nil {
         return LogError(fmt.Sprintf("Error reading environment file: %s - %v", envFilePath, err), err)
     }
 
-    LogInfo(fmt.Sprintf("Successfully sourced environment file: %s", envFilePath))
+    LogDebug(fmt.Sprintf("Successfully sourced environment file: %s", envFilePath))
     return nil
 }
 
@@ -142,7 +142,7 @@ func ProcessSingleNodeRule(element interface{}, client *http.Client, logs *Runne
         if HasValidRulePrefix(val) {
             return expect.CheckExpectations(logs.GetAllMessageString(), 0, []string{val}, client)
         } else {
-            LogDebug(fmt.Sprintf("Skipping check condition '%s' unsupported.", val))
+            LogInfo(fmt.Sprintf("Skipping check condition '%s' unsupported.", val))
         }
     case map[interface{}]interface{}:
         if expectVal, exists := val["expect"]; exists {
@@ -168,7 +168,7 @@ func ProcessResourceNodeRules(expectations []interface{}, client *http.Client, l
 
 // HasValidRulePrefix checks if the string has a valid prefix for checks.
 func HasValidRulePrefix(s string) bool {
-    prefixes := []string{"ENV:", "FILE:", "DIR:", "URL:", "CMD:", "EXEC:", "!"}
+    prefixes := []string{"ENV:", "FILE:", "DIR:", "URL:", "CMD:", "EXEC:", "!", "@", "!@"}
     for _, prefix := range prefixes {
         if strings.HasPrefix(s, prefix) {
             return true
@@ -279,7 +279,7 @@ func (dr *DependencyResolver) HandleRunCommand(resources []string) error {
 
 // ResolveResourceNodeDependency resolves the dependency for a given resource node.
 func (dr *DependencyResolver) ResolveResourceNodeDependency(resNode string, res ResourceNodeEntry, logs *RunnerLogs, client *http.Client) {
-    LogInfo("ð Resolving dependency " + resNode)
+    LogInfo("Resolving dependency " + resNode)
     if res.Run == nil {
         LogInfo("No run steps found for resource " + resNode)
         return
@@ -335,7 +335,7 @@ func (dr *DependencyResolver) BuildNodeSkipMap(steps []RunStep, resNode string, 
 // HandleResourceNodeStep handles the execution and logging of a step.
 func (dr *DependencyResolver) HandleResourceNodeStep(step RunStep, resNode string, skip map[StepKey]bool, logs *RunnerLogs, client *http.Client) {
     skipKey := StepKey{name: step.Name, node: resNode}
-    // LogDebug(fmt.Sprintf("Skip key '%v' = %v", skipKey, skip[skipKey]))
+    LogDebug(fmt.Sprintf("Skip key '%v' = %v", skipKey, skip[skipKey]))
 
     if skip[skipKey] {
         logs.Add(StepLog{targetRes: resNode, command: step.Exec, id: resNode, name: step.Name, message: "Step skipped."})

--- a/pkg/resolver/logging.go
+++ b/pkg/resolver/logging.go
@@ -1,68 +1,66 @@
 package resolver
 
 import (
-	"fmt"
-	"os"
+    "fmt"
+    "os"
 
-	"github.com/charmbracelet/log"
+    "github.com/charmbracelet/log"
 )
 
 var (
-	logger  = log.Default()
-	verbose = os.Getenv("VERBOSE")
+    logger  = log.Default()
+    verbose = os.Getenv("VERBOSE")
 )
 
 func shouldLog() bool {
-	return verbose != ""
+    return verbose != ""
 }
 
 func LogErrorExit(message string, err error) {
-	if shouldLog() {
-		msg := fmt.Sprintf("❌ %s: %s", message, err)
-		logger.Errorf(msg)
-	}
-	os.Exit(1)
+    if shouldLog() {
+        msg := fmt.Sprintf("❌ %s: %s", message, err)
+        logger.Errorf(msg)
+    }
+    os.Exit(1)
 }
 
 func LogError(message string, err error) error {
-	if shouldLog() {
-		msg := fmt.Sprintf("❌ %s: %s", message, err)
-		logger.Errorf(msg)
-		return fmt.Errorf(msg)
-	}
-	return err
+    if shouldLog() {
+        msg := fmt.Sprintf("❌ %s: %s", message, err)
+        logger.Errorf(msg)
+        return fmt.Errorf(msg)
+    }
+    return err
 }
 
 func LogInfo(message string) {
-	if shouldLog() {
-		logger.Info(message)
-	}
+    logger.Info(message)
 }
 
 func LogDebug(message string) {
-	if shouldLog() {
-		logger.Debug(message)
-	}
+    if shouldLog() {
+        logger.Debug(message)
+    }
 }
 
 func PrintMessage(format string, a ...interface{}) {
-	fmt.Printf(format, a...)
+    fmt.Printf(format, a...)
 }
 
 func Println(a ...interface{}) {
-	fmt.Println(a...)
+    fmt.Println(a...)
 }
 
 func PrintError(message string, err error) {
-	fmt.Printf("%s: %v\n", message, err)
+    fmt.Printf("%s: %v\n", message, err)
 }
 
 func LogWarn(message string) {
-	if shouldLog() {
-		logger.Warn(message)
-	}
+    if shouldLog() {
+        logger.Warn(message)
+    }
 }
 
 func GetLogger() *log.Logger {
-	return logger
+    return logger
 }


### PR DESCRIPTION
This PR adds persistent checking of preflight, postflight and skip conditions.

Persistent flag '@' can be prepended in all check prefixes except "ENV:".

For example, supposed you need the following URL to be available before executing the step, prepend it with "@".

```yaml
check:
  - "@URL:https://example.com:3000/api/v2"
```
Persistent flags can also be combined with negation, i.e.

```yaml
skip:
  - "@FILE:/tmp/tempfile.txt"
check:
  - "@URL:https://example.com:3000/api/v2"
expect:
  - "!@FILE:/tmp/file.sock"
```